### PR TITLE
Add fix for 'Undefined Index line 178' when using WP_DEBUG.

### DIFF
--- a/tealium/tealium.php
+++ b/tealium/tealium.php
@@ -170,13 +170,12 @@ function tealiumConvertCamelCase( $utagdata, $arrayHolder = array() ) {
 		$newKey = ltrim( $newKey, '_' );
 		if ( !is_array( $val ) ) {
 			$underscoreArray[$newKey] = $val;
+		} else if ( isset( $underscoreArray[$newKey] ) ) {
+			$underscoreArray[$newKey] = tealiumConvertCamelCase( $val, $underscoreArray[$newKey] );
+		} else if ( isset( $underscoreArray[$key] ) ) {
+			$underscoreArray[$newKey] = tealiumConvertCamelCase( $val, $underscoreArray[$key] );
 		} else {
-			if ( array_key_exists( $newKey, $underscoreArray ) ) {
-				$underscoreArray[$newKey] = tealiumConvertCamelCase( $val, $underscoreArray[$newKey] );
-			}
-			else {
-				$underscoreArray[$newKey] = tealiumConvertCamelCase( $val, $underscoreArray[$key] );
-			}
+			$underscoreArray[$newKey] = $val;
 		}
 	}
 	return $underscoreArray;


### PR DESCRIPTION
I always use `WP_DEBUG` during local development and the Tealium plugin throws an error when `$underscoreArray[$key]` is not set, on line `178`.  

You can see the error in the attached image.

<img width="826" alt="tealium-wp_debug" src="https://user-images.githubusercontent.com/153285/34141334-8a817eb8-e44e-11e7-8287-352753073f1e.png">

This pull request simply checks to see if `$underscoreArray[$key]` is set before accessing it, and it not it just assigns `$val` to the new array.

Hopefully you can see your want to adding this so we can use `WP_DEBUG` during development on a site using your plugin, as it catches lots of errors for us.